### PR TITLE
feat: Add effect/scope lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,27 @@
+## 2.3.0
+
+Status: Unreleased
+
+### ✨ NEW FEATURES
+
+#### Effect Lifecycle.
+
+We added the `onEffectStop` lifecycle API, which allows you to do some cleanup work before the effect/efrect-scope is stopped.
+
+```dart
+final stop = effect(null, () {
+  print('Effect started');
+
+  onEffectStop(() {
+    print('Effect stopped');
+  });
+});
+
+stop(); // Stop the effect, and run the cleanup function
+```
+
+You typically don't need to manually call stop (similar to dispose in other frameworks) within the widget scope unless you want to clean up immediately. Automatic disposal is safe and won't prevent garbage collection from occurring because you didn't call stop; signal nodes aren't collected immediately. However, effects will automatically orphan them, so there's no need to worry about updating a signal without calling stop and causing an unintended effect to fire.
+
 ## 2.2.0
 
 Status: Released (2025-09-25)

--- a/lib/oref.dart
+++ b/lib/oref.dart
@@ -10,3 +10,4 @@ export 'src/core/watch.dart';
 export 'src/core/untrack.dart';
 export 'src/core/signal_builder.dart';
 export 'src/core/reactive.dart';
+export 'src/core/lifecycle.dart' hide triggerEffectStopCallback;

--- a/lib/src/core/_utils.dart
+++ b/lib/src/core/_utils.dart
@@ -1,0 +1,11 @@
+import 'package:alien_signals/alien_signals.dart';
+
+(void Function(), ReactiveNode) createEffect(void Function() callback) {
+  ReactiveNode? sub;
+  final stop = effect(() {
+    sub ??= getCurrentSub();
+    callback();
+  });
+
+  return (stop, sub!);
+}

--- a/lib/src/core/effect.dart
+++ b/lib/src/core/effect.dart
@@ -1,6 +1,8 @@
 import 'package:alien_signals/alien_signals.dart' as alien;
 import 'package:flutter/widgets.dart';
 
+import '_utils.dart';
+import 'lifecycle.dart';
 import 'memoized.dart';
 import 'widget_scope.dart';
 
@@ -38,12 +40,20 @@ void Function() effect(
   bool detach = false,
 }) {
   if (context == null && !detach) {
-    return alien.effect(run);
+    final (stop, sub) = createEffect(run);
+    return () {
+      stop();
+      triggerEffectStopCallback(sub);
+    };
   } else if (context == null) {
     final prevScope = alien.setCurrentScope(null);
     final prevSub = alien.setCurrentSub(null);
     try {
-      return alien.effect(run);
+      final (stop, sub) = createEffect(run);
+      return () {
+        stop();
+        triggerEffectStopCallback(sub);
+      };
     } finally {
       alien.setCurrentScope(prevScope);
       alien.setCurrentSub(prevSub);
@@ -55,7 +65,11 @@ void Function() effect(
       final prevScope = alien.setCurrentScope(null);
       final prevSub = alien.setCurrentSub(null);
       try {
-        return _Mask(alien.effect(run));
+        final (stop, sub) = createEffect(run);
+        return _Mask(() {
+          stop();
+          triggerEffectStopCallback(sub);
+        });
       } finally {
         alien.setCurrentScope(prevScope);
         alien.setCurrentSub(prevSub);
@@ -63,11 +77,21 @@ void Function() effect(
     }
 
     if (alien.getCurrentScope() != null) {
-      return _Mask(alien.effect(run));
+      final (stop, sub) = createEffect(run);
+      return _Mask(() {
+        triggerEffectStopCallback(sub);
+        stop();
+      });
     }
 
     final scope = useWidgetScope(context);
-    return scope.using(() => _Mask(alien.effect(run)));
+    return scope.using(() {
+      final (stop, sub) = createEffect(run);
+      return _Mask(() {
+        triggerEffectStopCallback(sub);
+        stop();
+      });
+    });
   });
 
   return mask.stop;

--- a/lib/src/core/lifecycle.dart
+++ b/lib/src/core/lifecycle.dart
@@ -1,0 +1,49 @@
+import 'package:alien_signals/alien_signals.dart';
+import 'package:flutter/foundation.dart' show internal;
+
+class _EffectStopLink {
+  _EffectStopLink({required this.callback, _EffectStopLink? head}) {
+    this.head = head ?? this;
+  }
+
+  final void Function() callback;
+
+  _EffectStopLink? next;
+  late _EffectStopLink head;
+}
+
+final _links = Expando<_EffectStopLink>("oref:core.lifecycle");
+
+void _registerEffectStopCallback(ReactiveNode sub, void Function() callback) {
+  final prev = _links[sub], head = prev?.head;
+  final link = _EffectStopLink(callback: callback, head: head);
+
+  prev?.next = link;
+  _links[sub] = link;
+}
+
+void onEffectStop(void Function() callback) {
+  final sub = getCurrentSub();
+
+  assert(sub != null, "onEffectStop can only be called inside an effect");
+  if (sub != null) {
+    _registerEffectStopCallback(sub, callback);
+  }
+}
+
+@internal
+void triggerEffectStopCallback(ReactiveNode sub) {
+  _EffectStopLink? link = _links[sub]?.head;
+  _links[sub] = null;
+
+  while (link != null) {
+    try {
+      link.callback();
+    } catch (_) {}
+    link = link.next;
+  }
+
+  for (Link? link = sub.subs; link != null; link = link.nextSub) {
+    triggerEffectStopCallback(link.sub);
+  }
+}

--- a/lib/src/core/widget_scope.dart
+++ b/lib/src/core/widget_scope.dart
@@ -1,6 +1,8 @@
 import 'package:alien_signals/alien_signals.dart';
 import 'package:flutter/widgets.dart';
 
+import 'lifecycle.dart';
+
 /// Widget effect scope.
 ///
 /// {@template oref.core.widget_scope}
@@ -32,6 +34,7 @@ class WidgetScope {
   }
 
   void stop() {
+    triggerEffectStopCallback(effectScope);
     _stop();
     _finalizer.detach(effectScope);
   }
@@ -50,15 +53,12 @@ WidgetScope useWidgetScope(BuildContext context) {
     final stop = effectScope(() {
       scope ??= getCurrentScope();
     });
+    final effect = WidgetScope(stop: stop, effectScope: scope!);
 
-    assert(scope != null, "oref: Widget scope initialization failed");
+    _store[context] = effect;
+    _finalizer.attach(context, effect, detach: scope);
 
-    final e = WidgetScope(stop: stop, effectScope: scope!);
-
-    _store[context] = e;
-    _finalizer.attach(context, e, detach: scope);
-
-    return e;
+    return effect;
   } finally {
     setCurrentScope(prevScope);
   }

--- a/test/core/lifecycle_test.dart
+++ b/test/core/lifecycle_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oref/oref.dart';
+
+void main() {
+  test("Normal effect stop with clean", () {
+    bool clean = false;
+    int tick = 0;
+
+    final src = signal(null, 0);
+    final stop = effect(null, () {
+      src();
+      tick++;
+
+      onEffectStop(() {
+        clean = true;
+      });
+    });
+
+    expect(clean, equals(false));
+    expect(tick, equals(1));
+
+    src(1);
+    expect(clean, equals(false));
+    expect(tick, equals(2));
+
+    stop();
+    expect(clean, equals(true));
+    expect(tick, equals(2));
+
+    clean = false;
+    src(2);
+    expect(clean, equals(false));
+    expect(tick, equals(2));
+  });
+}


### PR DESCRIPTION
```dart
final stop = effect(null, () {
  print('Effect started');

  onEffectStop(() {
    print('Effect stopped');
  });
});

stop(); // Stop the effect, and run the cleanup function
```