### PR TITLE
Fix widget unmount disposal for effects/scopes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+- Ensure widget-scoped effects and scopes dispose on widget unmount so `onEffectDispose` runs promptly ([#31](https://github.com/medz/oref/issues/31)).
+
 ## 2.6.0
 
 ### Compatibility

--- a/example/test/example_app_test.dart
+++ b/example/test/example_app_test.dart
@@ -14,7 +14,9 @@ String readText(WidgetTester tester, String startsWith) {
 }
 
 Widget wrap(Widget child) {
-  return MaterialApp(home: Scaffold(body: Center(child: child)));
+  return MaterialApp(
+    home: Scaffold(body: Center(child: child)),
+  );
 }
 
 void main() {
@@ -61,7 +63,9 @@ void main() {
     expect(readText(tester, 'effect runs:'), contains('3'));
   });
 
-  testWidgets('untrack ignores noise updates until source changes', (tester) async {
+  testWidgets('untrack ignores noise updates until source changes', (
+    tester,
+  ) async {
     await tester.pumpWidget(wrap(const UntrackSection()));
     await tester.pumpAndSettle();
 
@@ -133,7 +137,9 @@ void main() {
     expect(readText(tester, 'showing'), contains('6 of 6'));
   });
 
-  testWidgets('checkout walkthrough updates totals and autosave', (tester) async {
+  testWidgets('checkout walkthrough updates totals and autosave', (
+    tester,
+  ) async {
     await tester.pumpWidget(wrap(const CheckoutWorkflowSection()));
     await tester.pumpAndSettle();
 

--- a/lib/src/core/_element_disposer.dart
+++ b/lib/src/core/_element_disposer.dart
@@ -30,17 +30,27 @@ void _ensureFrameCallback() {
 void _handleFrame(Duration _) {
   if (_trackedDisposers.isEmpty) return;
 
-  _trackedDisposers.removeWhere((entry) {
-    final element = entry.element.target;
+  final toRemove = <_ElementDisposer>[];
+  final toDispose = <_ElementDisposer>[];
+
+  for (final disposer in List<_ElementDisposer>.from(_trackedDisposers)) {
+    final element = disposer.element.target;
     if (element == null) {
-      return true;
+      toRemove.add(disposer);
+      continue;
     }
 
     if (!element.mounted) {
-      entry.dispose();
-      return true;
+      toRemove.add(disposer);
+      toDispose.add(disposer);
     }
+  }
 
-    return false;
-  });
+  if (toRemove.isNotEmpty) {
+    _trackedDisposers.removeWhere(toRemove.contains);
+  }
+
+  for (final disposer in toDispose) {
+    disposer.dispose();
+  }
 }

--- a/lib/src/core/_element_disposer.dart
+++ b/lib/src/core/_element_disposer.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/widgets.dart';
+
+class _ElementDisposer {
+  _ElementDisposer(this.element, this.dispose);
+
+  final WeakReference<Element> element;
+  final VoidCallback dispose;
+}
+
+final Set<_ElementDisposer> _trackedDisposers = <_ElementDisposer>{};
+bool _frameCallbackInstalled = false;
+
+void registerElementDisposer(BuildContext context, VoidCallback dispose) {
+  if (context is! Element) return;
+
+  _ensureFrameCallback();
+  _trackedDisposers.add(
+    _ElementDisposer(WeakReference<Element>(context), dispose),
+  );
+}
+
+void _ensureFrameCallback() {
+  if (_frameCallbackInstalled) return;
+  _frameCallbackInstalled = true;
+
+  WidgetsFlutterBinding.ensureInitialized();
+  WidgetsBinding.instance.addPersistentFrameCallback(_handleFrame);
+}
+
+void _handleFrame(Duration _) {
+  if (_trackedDisposers.isEmpty) return;
+
+  _trackedDisposers.removeWhere((entry) {
+    final element = entry.element.target;
+    if (element == null) {
+      return true;
+    }
+
+    if (!element.mounted) {
+      entry.dispose();
+      return true;
+    }
+
+    return false;
+  });
+}

--- a/lib/src/core/effect.dart
+++ b/lib/src/core/effect.dart
@@ -52,11 +52,7 @@ alien.Effect effect(
     final scope = useWidgetScope(context);
     final prevSub = alien.setActiveSub(scope as alien.ReactiveNode);
     try {
-      return _createEffect(
-        context: context,
-        callback: callback,
-        detach: false,
-      );
+      return _createEffect(context: context, callback: callback, detach: false);
     } finally {
       alien.setActiveSub(prevSub);
     }
@@ -109,7 +105,7 @@ _OrefEffect _createEffect({
   });
   if (context != null) {
     _OrefEffect.finalizer.attach(context, effect, detach: effect);
-    registerElementDisposer(context, effect);
+    registerElementDisposer(context, effect.call);
   }
 
   final prevSub = alien.setActiveSub(effect);

--- a/lib/src/core/effect.dart
+++ b/lib/src/core/effect.dart
@@ -4,6 +4,7 @@ import 'package:alien_signals/preset.dart' as alien;
 import 'package:flutter/widgets.dart';
 
 import '_warn.dart';
+import '_element_disposer.dart';
 import 'memoized.dart';
 import 'widget_scope.dart';
 
@@ -41,13 +42,21 @@ alien.Effect effect(
 
   final e = useMemoized(context, () {
     if (detach || alien.getActiveSub() != null) {
-      return _createEffect(callback: callback, detach: detach);
+      return _createEffect(
+        context: context,
+        callback: callback,
+        detach: detach,
+      );
     }
 
     final scope = useWidgetScope(context);
     final prevSub = alien.setActiveSub(scope as alien.ReactiveNode);
     try {
-      return _createEffect(callback: callback, detach: false);
+      return _createEffect(
+        context: context,
+        callback: callback,
+        detach: false,
+      );
     } finally {
       alien.setActiveSub(prevSub);
     }
@@ -100,6 +109,7 @@ _OrefEffect _createEffect({
   });
   if (context != null) {
     _OrefEffect.finalizer.attach(context, effect, detach: effect);
+    registerElementDisposer(context, effect);
   }
 
   final prevSub = alien.setActiveSub(effect);

--- a/lib/src/core/effect_scope.dart
+++ b/lib/src/core/effect_scope.dart
@@ -4,6 +4,7 @@ import 'package:alien_signals/preset.dart' as alien;
 import 'package:flutter/widgets.dart';
 
 import '_warn.dart';
+import '_element_disposer.dart';
 import 'memoized.dart';
 import 'widget_scope.dart';
 
@@ -68,6 +69,7 @@ _OrefEffectScope _createEffectScope({
   final scope = _OrefEffectScope(), prevSub = alien.setActiveSub(scope);
   if (context != null) {
     _OrefEffectScope.finalizer.attach(context, scope, detach: scope);
+    registerElementDisposer(context, scope);
   }
 
   if (prevSub != null && !detach) {

--- a/lib/src/core/effect_scope.dart
+++ b/lib/src/core/effect_scope.dart
@@ -69,7 +69,7 @@ _OrefEffectScope _createEffectScope({
   final scope = _OrefEffectScope(), prevSub = alien.setActiveSub(scope);
   if (context != null) {
     _OrefEffectScope.finalizer.attach(context, scope, detach: scope);
-    registerElementDisposer(context, scope);
+    registerElementDisposer(context, scope.call);
   }
 
   if (prevSub != null && !detach) {

--- a/lib/src/core/widget_scope.dart
+++ b/lib/src/core/widget_scope.dart
@@ -1,6 +1,7 @@
 import 'package:alien_signals/alien_signals.dart' as alien;
 import 'package:flutter/widgets.dart';
 
+import '_element_disposer.dart';
 import 'context.dart';
 import 'effect_scope.dart';
 
@@ -13,6 +14,7 @@ alien.EffectScope useWidgetScope(BuildContext context) {
 
   final scope = effectScope(null, _noop, detach: true);
   _store[context] = scope;
+  registerElementDisposer(context, scope);
 
   return scope;
 }

--- a/lib/src/core/widget_scope.dart
+++ b/lib/src/core/widget_scope.dart
@@ -14,7 +14,7 @@ alien.EffectScope useWidgetScope(BuildContext context) {
 
   final scope = effectScope(null, _noop, detach: true);
   _store[context] = scope;
-  registerElementDisposer(context, scope);
+  registerElementDisposer(context, scope.call);
 
   return scope;
 }

--- a/test/collections/reactive_list_test.dart
+++ b/test/collections/reactive_list_test.dart
@@ -274,17 +274,23 @@ void main() {
 
       list.add(4);
       expect(effect1Count, equals(2));
-      expect(effect2Count, equals(2)); // coarse-grained: any mutation triggers all effects
+      expect(
+        effect2Count,
+        equals(2),
+      ); // coarse-grained: any mutation triggers all effects
 
       list[0] = 10;
-      expect(effect1Count, equals(3)); // coarse-grained: any mutation triggers all effects
+      expect(
+        effect1Count,
+        equals(3),
+      ); // coarse-grained: any mutation triggers all effects
       expect(effect2Count, equals(3));
     });
 
     test('list with complex objects', () {
       final list = ReactiveList<Map<String, int>>([
         {'a': 1},
-        {'b': 2}
+        {'b': 2},
       ]);
 
       expect(list[0]['a'], equals(1));

--- a/test/collections/reactive_map_test.dart
+++ b/test/collections/reactive_map_test.dart
@@ -222,17 +222,23 @@ void main() {
 
       map['c'] = 3;
       expect(effect1Count, equals(2));
-      expect(effect2Count, equals(2)); // coarse-grained: any mutation triggers all effects
+      expect(
+        effect2Count,
+        equals(2),
+      ); // coarse-grained: any mutation triggers all effects
 
       map['a'] = 10;
-      expect(effect1Count, equals(3)); // coarse-grained: any mutation triggers all effects
+      expect(
+        effect1Count,
+        equals(3),
+      ); // coarse-grained: any mutation triggers all effects
       expect(effect2Count, equals(3));
     });
 
     test('map with complex values', () {
       final map = ReactiveMap<String, List<int>>({
         'a': [1, 2, 3],
-        'b': [4, 5, 6]
+        'b': [4, 5, 6],
       });
 
       expect(map['a'], equals([1, 2, 3]));
@@ -301,7 +307,10 @@ void main() {
       expect(effectCount, equals(2));
 
       map.putIfAbsent('a', () => 10); // Should not add or trigger
-      expect(effectCount, equals(2)); // Should not trigger since no modification
+      expect(
+        effectCount,
+        equals(2),
+      ); // Should not trigger since no modification
       expect(map['a'], equals(1)); // Value unchanged
     });
   });

--- a/test/core/effect_test.dart
+++ b/test/core/effect_test.dart
@@ -429,8 +429,9 @@ void main() {
       expect(buildCount, equals(2));
     });
 
-    testWidgets('effect with conditional dependencies in widget',
-        (tester) async {
+    testWidgets('effect with conditional dependencies in widget', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Builder(

--- a/test/core/reactive_test.dart
+++ b/test/core/reactive_test.dart
@@ -451,8 +451,7 @@ void main() {
       expect(find.text('Doubled: 2'), findsOneWidget);
     });
 
-    testWidgets('reactive with conditional tracking in widget',
-        (tester) async {
+    testWidgets('reactive with conditional tracking in widget', (tester) async {
       final counter1 = Counter();
       final counter2 = Counter();
       counter2.set(10);

--- a/test/issues/issue_31_test.dart
+++ b/test/issues/issue_31_test.dart
@@ -156,40 +156,39 @@ void main() {
     });
 
     // Issue #31: controllers created in effects should be disposed on widget unmount.
-    testWidgets(
-      'TextEditingController is disposed when widget is unmounted',
-      (tester) async {
-        _TestTextController? controller;
-        bool showChild = true;
-        late StateSetter setState;
+    testWidgets('TextEditingController is disposed when widget is unmounted', (
+      tester,
+    ) async {
+      _TestTextController? controller;
+      bool showChild = true;
+      late StateSetter setState;
 
-        await tester.pumpWidget(
-          MaterialApp(
-            home: StatefulBuilder(
-              builder: (context, updateState) {
-                setState = updateState;
-                return showChild
-                    ? _ControllerDisposeProbe(
-                        onCreate: (created) {
-                          controller = created;
-                        },
-                      )
-                    : const SizedBox();
-              },
-            ),
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StatefulBuilder(
+            builder: (context, updateState) {
+              setState = updateState;
+              return showChild
+                  ? _ControllerDisposeProbe(
+                      onCreate: (created) {
+                        controller = created;
+                      },
+                    )
+                  : const SizedBox();
+            },
           ),
-        );
+        ),
+      );
 
-        expect(controller, isNotNull);
-        expect(controller!.disposed, isFalse);
+      expect(controller, isNotNull);
+      expect(controller!.disposed, isFalse);
 
-        showChild = false;
-        setState(() {});
-        await tester.pump();
+      showChild = false;
+      setState(() {});
+      await tester.pump();
 
-        expect(controller!.disposed, isTrue);
-      },
-    );
+      expect(controller!.disposed, isTrue);
+    });
   });
 }
 

--- a/test/issues/issue_31_test.dart
+++ b/test/issues/issue_31_test.dart
@@ -1,0 +1,286 @@
+import 'dart:async';
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:oref/oref.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('Issue #31', () {
+    // Issue #31: onEffectDispose should run when the widget is unmounted.
+    testWidgets('onEffectDispose runs when widget is unmounted', (
+      tester,
+    ) async {
+      bool disposed = false;
+      bool showChild = true;
+      late StateSetter setState;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StatefulBuilder(
+            builder: (context, updateState) {
+              setState = updateState;
+              return showChild
+                  ? _EffectDisposeProbe(
+                      onDispose: () {
+                        disposed = true;
+                      },
+                    )
+                  : const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(disposed, isFalse);
+
+      showChild = false;
+      setState(() {});
+      await tester.pump();
+
+      expect(disposed, isTrue);
+    });
+
+    // Issue #31: onEffectDispose should run once after effect re-executions.
+    testWidgets(
+      'onEffectDispose runs once after multiple effect re-executions',
+      (tester) async {
+        final count = signal<int>(null, 0);
+        int runCount = 0;
+        int disposeCount = 0;
+        bool showChild = true;
+        late StateSetter setState;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: StatefulBuilder(
+              builder: (context, updateState) {
+                setState = updateState;
+                return showChild
+                    ? _EffectReexecProbe(
+                        count: count,
+                        onRun: () {
+                          runCount++;
+                        },
+                        onDispose: () {
+                          disposeCount++;
+                        },
+                      )
+                    : const SizedBox();
+              },
+            ),
+          ),
+        );
+
+        expect(runCount, equals(1));
+        expect(disposeCount, equals(0));
+
+        count.set(1);
+        await tester.pump();
+
+        expect(runCount, equals(2));
+        expect(disposeCount, equals(0));
+
+        showChild = false;
+        setState(() {});
+        await tester.pump();
+
+        expect(disposeCount, equals(1));
+      },
+    );
+
+    // Issue #31: effect scopes should dispose on widget unmount.
+    testWidgets('onScopeDispose runs when widget is unmounted', (tester) async {
+      bool disposed = false;
+      bool showChild = true;
+      late StateSetter setState;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StatefulBuilder(
+            builder: (context, updateState) {
+              setState = updateState;
+              return showChild
+                  ? _ScopeDisposeProbe(
+                      onDispose: () {
+                        disposed = true;
+                      },
+                    )
+                  : const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(disposed, isFalse);
+
+      showChild = false;
+      setState(() {});
+      await tester.pump();
+
+      expect(disposed, isTrue);
+    });
+
+    // Issue #31: timers created in effects should be cancelled on widget unmount.
+    testWidgets('timer is cancelled when widget is unmounted', (tester) async {
+      Timer? timer;
+      bool showChild = true;
+      late StateSetter setState;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: StatefulBuilder(
+            builder: (context, updateState) {
+              setState = updateState;
+              return showChild
+                  ? _TimerDisposeProbe(
+                      onCreate: (created) {
+                        timer = created;
+                      },
+                    )
+                  : const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(timer, isNotNull);
+      expect(timer!.isActive, isTrue);
+
+      showChild = false;
+      setState(() {});
+      await tester.pump();
+
+      expect(timer!.isActive, isFalse);
+    });
+
+    // Issue #31: controllers created in effects should be disposed on widget unmount.
+    testWidgets(
+      'TextEditingController is disposed when widget is unmounted',
+      (tester) async {
+        _TestTextController? controller;
+        bool showChild = true;
+        late StateSetter setState;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: StatefulBuilder(
+              builder: (context, updateState) {
+                setState = updateState;
+                return showChild
+                    ? _ControllerDisposeProbe(
+                        onCreate: (created) {
+                          controller = created;
+                        },
+                      )
+                    : const SizedBox();
+              },
+            ),
+          ),
+        );
+
+        expect(controller, isNotNull);
+        expect(controller!.disposed, isFalse);
+
+        showChild = false;
+        setState(() {});
+        await tester.pump();
+
+        expect(controller!.disposed, isTrue);
+      },
+    );
+  });
+}
+
+class _EffectDisposeProbe extends StatelessWidget {
+  const _EffectDisposeProbe({required this.onDispose});
+
+  final VoidCallback onDispose;
+
+  @override
+  Widget build(BuildContext context) {
+    effect(context, () {
+      onEffectDispose(onDispose);
+    });
+    return const SizedBox();
+  }
+}
+
+class _EffectReexecProbe extends StatelessWidget {
+  const _EffectReexecProbe({
+    required this.count,
+    required this.onRun,
+    required this.onDispose,
+  });
+
+  final WritableSignal<int> count;
+  final VoidCallback onRun;
+  final VoidCallback onDispose;
+
+  @override
+  Widget build(BuildContext context) {
+    effect(context, () {
+      count();
+      onRun();
+      onEffectDispose(onDispose);
+    });
+    return const SizedBox();
+  }
+}
+
+class _ScopeDisposeProbe extends StatelessWidget {
+  const _ScopeDisposeProbe({required this.onDispose});
+
+  final VoidCallback onDispose;
+
+  @override
+  Widget build(BuildContext context) {
+    effectScope(context, () {
+      onScopeDispose(onDispose);
+    });
+    return const SizedBox();
+  }
+}
+
+class _TimerDisposeProbe extends StatelessWidget {
+  const _TimerDisposeProbe({required this.onCreate});
+
+  final ValueSetter<Timer> onCreate;
+
+  @override
+  Widget build(BuildContext context) {
+    effect(context, () {
+      final timer = Timer(const Duration(days: 1), () {});
+      onCreate(timer);
+      onEffectDispose(timer.cancel);
+    });
+    return const SizedBox();
+  }
+}
+
+class _ControllerDisposeProbe extends StatelessWidget {
+  const _ControllerDisposeProbe({required this.onCreate});
+
+  final ValueSetter<_TestTextController> onCreate;
+
+  @override
+  Widget build(BuildContext context) {
+    final controller = useMemoized(context, _TestTextController.new);
+    onCreate(controller);
+    effect(context, () {
+      onEffectDispose(controller.dispose);
+    });
+    return const SizedBox();
+  }
+}
+
+class _TestTextController extends TextEditingController {
+  bool disposed = false;
+
+  @override
+  void dispose() {
+    disposed = true;
+    super.dispose();
+  }
+}


### PR DESCRIPTION
Resolves #31

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Widget-scoped effects and scopes now reliably dispose on unmount so onEffectDispose/onScopeDispose run promptly.

* **Tests**
  * Added comprehensive lifecycle and disposal tests covering effects, scopes, timers, and controller cleanup.

* **Style**
  * Formatting refinements across test and example code (no behavioral changes).

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->