### PR TITLE
fix(async): refetch AsyncData after pending changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## Unreleased
+
+### Bug Fixes
+
+- fix(async): ensure AsyncData re-fetches when dependencies change during a pending request.
+
 ## 2.7.0
 
 ### Features


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where AsyncData did not properly re-fetch when dependencies changed during a pending request.

* **Tests**
  * Added tests validating re-fetching behavior when signal or computed dependencies change during pending operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->