### PR TITLE
feat: auto-dispose effect/scope on setup failure, upgrade alien_signals to 2.3.1

### DIFF
--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -13,10 +13,10 @@ packages:
     dependency: transitive
     description:
       name: alien_signals
-      sha256: "0e198fe6913f91a386f3d121ec715319496d6643900739f76d3b39d026196530"
+      sha256: "3debc27514ab6a24e6cfba340a0e45b48f9b6684c49a01544ed88c7657c367e2"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.1"
   analysis_server_plugin:
     dependency: transitive
     description:
@@ -207,10 +207,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.17.0"
+    version: "1.18.0"
   oref:
     dependency: "direct main"
     description:
@@ -291,10 +291,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.10"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:

--- a/lib/src/core/effect.dart
+++ b/lib/src/core/effect.dart
@@ -149,6 +149,7 @@ _OrefEffect _createEffect({
   final prevSub = alien.setActiveSub(effect);
   if (prevSub != null && !detach) {
     alien.link(effect, prevSub, 0);
+    prevSub.flags |= 64 as alien.ReactiveFlags; // hasChildEffect
   }
 
   try {

--- a/lib/src/core/effect.dart
+++ b/lib/src/core/effect.dart
@@ -108,7 +108,7 @@ void onEffectDispose(void Function() callback, {bool failSilently = false}) {
 void onEffectCleanup(void Function() callback, {bool failSilently = false}) {
   final sub = alien.getActiveSub();
   if (sub is _OrefEffect) {
-    sub.cleanup = callback;
+    sub._userCleanup = callback;
   } else if (!failSilently) {
     warn(
       '`onEffectCleanup()` was called when there was no active effect to assign the callback to.',
@@ -154,6 +154,9 @@ _OrefEffect _createEffect({
   try {
     run();
     return effect;
+  } catch (_) {
+    effect();
+    rethrow;
   } finally {
     alien.setActiveSub(prevSub);
     effect.flags &= -5 /*~ReactiveFlags.recursedCheck*/;
@@ -171,7 +174,7 @@ class _OrefEffect extends alien.EffectNode implements alien.Effect {
 
   VoidCallback callback;
   void Function()? onDispose;
-  void Function()? cleanup;
+  void Function()? _userCleanup;
   EffectHandle? _devtools;
 
   void attachDevTools(EffectHandle handle) {
@@ -186,20 +189,6 @@ class _OrefEffect extends alien.EffectNode implements alien.Effect {
     _devtools?.dispose();
     onDispose?.call();
     onDispose = null;
-    for (alien.Link? link = deps; link != null; link = link.nextDep) {
-      switch (link.dep) {
-        case alien.EffectScope scope:
-          scope();
-          break;
-        case alien.Effect effect:
-          effect();
-          break;
-        case alien.EffectNode node:
-          alien.stop(node);
-          break;
-      }
-    }
-
     alien.stop(this);
     finalizer.detach(this);
   }
@@ -211,8 +200,8 @@ VoidCallback _wrapEffectCallback(
 ) {
   return () {
     final effect = effectGetter();
-    effect.cleanup?.call();
-    effect.cleanup = null;
+    effect._userCleanup?.call();
+    effect._userCleanup = null;
     final handle = effect._devtools;
     final token = handle?.start();
     try {

--- a/lib/src/core/effect.dart
+++ b/lib/src/core/effect.dart
@@ -187,6 +187,8 @@ class _OrefEffect extends alien.EffectNode implements alien.Effect {
   @override
   void call() {
     _devtools?.dispose();
+    _userCleanup?.call();
+    _userCleanup = null;
     onDispose?.call();
     onDispose = null;
     alien.stop(this);

--- a/lib/src/core/effect.dart
+++ b/lib/src/core/effect.dart
@@ -192,6 +192,11 @@ class _OrefEffect extends alien.EffectNode implements alien.Effect {
     onDispose?.call();
     onDispose = null;
     alien.stop(this);
+    // If this effect is the active subscriber, clear it so subsequent signal
+    // reads in the same callback won't re-link to this stopped node.
+    if (identical(alien.getActiveSub(), this)) {
+      alien.setActiveSub(null);
+    }
     finalizer.detach(this);
   }
 }

--- a/lib/src/core/effect_scope.dart
+++ b/lib/src/core/effect_scope.dart
@@ -79,15 +79,18 @@ _OrefEffectScope _createEffectScope({
   try {
     callback();
     return scope;
+  } catch (_) {
+    scope();
+    rethrow;
   } finally {
     alien.setActiveSub(prevSub);
   }
 }
 
-class _OrefEffectScope extends alien.ReactiveNode implements alien.EffectScope {
+class _OrefEffectScope extends alien.EffectScopeNode implements alien.EffectScope {
   static final finalizer = Finalizer<_OrefEffectScope>((scope) => scope());
 
-  _OrefEffectScope() : super(flags: .none);
+  _OrefEffectScope() : super(flags: .mutable);
 
   void Function()? onDispose;
 
@@ -95,20 +98,6 @@ class _OrefEffectScope extends alien.ReactiveNode implements alien.EffectScope {
   void call() {
     onDispose?.call();
     onDispose = null;
-    for (alien.Link? link = deps; link != null; link = link.nextDep) {
-      switch (link.dep) {
-        case alien.EffectScope scope:
-          scope();
-          break;
-        case alien.Effect effect:
-          effect();
-          break;
-        case alien.EffectNode node:
-          alien.stop(node);
-          break;
-      }
-    }
-
     alien.stop(this);
     finalizer.detach(this);
   }

--- a/lib/src/core/effect_scope.dart
+++ b/lib/src/core/effect_scope.dart
@@ -74,6 +74,7 @@ _OrefEffectScope _createEffectScope({
 
   if (prevSub != null && !detach) {
     alien.link(scope, prevSub, 0);
+    prevSub.flags |= 64 as alien.ReactiveFlags; // hasChildEffect
   }
 
   try {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -21,7 +21,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  alien_signals: ^2.2.0
+  alien_signals: ^2.3.1
   analyzer: ^10.0.1
   analysis_server_plugin: ^0.3.7
   analyzer_plugin: ^0.14.1

--- a/test/core/effect_test.dart
+++ b/test/core/effect_test.dart
@@ -681,6 +681,41 @@ void main() {
     );
   });
 
+  group('Effect hasChildEffect flag', () {
+    test('parent effect disposes stale child effects before re-running', () {
+      // Without hasChildEffect on the parent, stale child effects from a
+      // previous run stay linked. If the parent callback writes to a signal
+      // that the stale child depends on, the stale child triggers before
+      // purgeDeps cleans it up — causing duplicate work.
+      final toggle = signal(null, true);
+      final source = signal(null, 0);
+      int childRuns = 0;
+
+      effect(null, () {
+        toggle();
+        if (toggle()) {
+          effect(null, () {
+            source();
+            childRuns++;
+          });
+        } else {
+          // Parent re-run: if hasChildEffect is set, the stale child was
+          // already disposed. source.set() should NOT trigger it.
+          source.set(99);
+        }
+      });
+
+      expect(childRuns, 1);
+
+      toggle.set(false);
+
+      // If hasChildEffect is missing: stale child triggers on source.set(99)
+      // → childRuns = 2. If set: stale child already disposed → childRuns = 1.
+      expect(childRuns, 1,
+          reason: 'stale child was disposed before parent re-run');
+    });
+  });
+
   group('Effect auto-dispose with Flutter Widget Context', () {
     testWidgets('failed effect setup in widget does not leave subscription',
         (tester) async {

--- a/test/core/effect_test.dart
+++ b/test/core/effect_test.dart
@@ -640,6 +640,45 @@ void main() {
         expect(runs, 2);
       },
     );
+
+    test(
+      'after stop(), activeSub persists and re-links signals read post-stop',
+      () {
+        // Verifies: when an effect calls its own disposer in the callback,
+        // activeSub is still the effect until _wrapEffectCallback returns.
+        // In alien_signals 2.3.1, SignalNode.get() unconditionally links to
+        // activeSub, so any signal read after stop() re-links the disposed
+        // effect. The effect won't re-execute (run() guard prevents it), but
+        // the stale link causes unnecessary propagation on every signal change.
+        final trigger = signal(null, 0);
+        final postStop = signal(null, 0);
+        Effect? stopper;
+        bool shouldStop = false;
+        int runs = 0;
+
+        stopper = effect(null, () {
+          runs++;
+          trigger();
+          if (shouldStop) {
+            stopper!();
+            postStop(); // re-links via activeSub — unnecessary propagation
+          }
+        });
+
+        expect(runs, 1);
+
+        shouldStop = true;
+        trigger.set(1);
+        expect(runs, 2);
+
+        // postStop was re-linked. Its changes trigger useless propagation
+        // through the stopped effect, but never cause re-execution.
+        postStop.set(1);
+        expect(runs, 2);
+        postStop.set(2);
+        expect(runs, 2);
+      },
+    );
   });
 
   group('Effect auto-dispose with Flutter Widget Context', () {

--- a/test/core/effect_test.dart
+++ b/test/core/effect_test.dart
@@ -564,7 +564,7 @@ void main() {
     });
   });
 
-  group('Effect auto-dispose on setup failure', () {
+  group('Effect auto-dispose behavior', () {
     test('failed effect setup does not leave a live subscription behind', () {
       final source = signal(null, 0);
       int runs = 0;
@@ -645,7 +645,7 @@ void main() {
   group('Effect auto-dispose with Flutter Widget Context', () {
     testWidgets('failed effect setup in widget does not leave subscription',
         (tester) async {
-      final source = signal<Object?>(null, 0);
+      final source = signal(null, 0);
       int runs = 0;
       bool caught = false;
 
@@ -674,7 +674,7 @@ void main() {
       expect(caught, isTrue);
 
       // Trigger the signal — the broken effect should not re-run.
-      (source as WritableSignal<Object?>).set(1);
+      source.set(1);
       await tester.pump();
 
       expect(runs, 1);
@@ -683,7 +683,7 @@ void main() {
     testWidgets(
         'failed effect scope in widget disposes child effects created before throw',
         (tester) async {
-      final source = signal<Object?>(null, 0);
+      final source = signal(null, 0);
       int childRuns = 0;
       bool caught = false;
 
@@ -714,7 +714,7 @@ void main() {
       expect(caught, isTrue);
 
       // The child effect should be disposed — signal change should not re-run it.
-      (source as WritableSignal<Object?>).set(1);
+      source.set(1);
       await tester.pump();
 
       expect(childRuns, 1);

--- a/test/core/effect_test.dart
+++ b/test/core/effect_test.dart
@@ -563,4 +563,161 @@ void main() {
       expect(find.text('Output2: 3'), findsOneWidget);
     });
   });
+
+  group('Effect auto-dispose on setup failure', () {
+    test('failed effect setup does not leave a live subscription behind', () {
+      final source = signal(null, 0);
+      int runs = 0;
+
+      expect(
+        () => effect(null, () {
+          runs++;
+          source();
+          throw StateError('setup failed');
+        }),
+        throwsStateError,
+      );
+
+      expect(runs, 1);
+      // If cleanup worked, changing source should not re-run the broken effect.
+      expect(() => source.set(1), returnsNormally);
+      expect(runs, 1);
+    });
+
+    test(
+      'failed effect scope setup disposes child effects created before throw',
+      () {
+        final source = signal(null, 0);
+        int childRuns = 0;
+
+        expect(
+          () => effectScope(null, () {
+            effect(null, () {
+              childRuns++;
+              source();
+            });
+            throw StateError('scope setup failed');
+          }),
+          throwsStateError,
+        );
+
+        expect(childRuns, 1);
+        // If cleanup worked, changing source should not re-run the child effect.
+        source.set(1);
+        expect(childRuns, 1);
+      },
+    );
+
+    test(
+      'stopped effect does not subscribe to signals read later in the same run',
+      () {
+        final rerun = signal(null, 0);
+        final readAfterStop = signal(null, 0);
+        Effect? stop;
+        bool stopDuringRun = false;
+        int runs = 0;
+
+        stop = effect(null, () {
+          runs++;
+          rerun();
+          if (stopDuringRun) {
+            stop!();
+            // Reading a signal after stopping should not create a subscription.
+            readAfterStop();
+          }
+        });
+
+        expect(runs, 1);
+
+        stopDuringRun = true;
+        rerun.set(1);
+
+        // The effect should have run a second time (before stopping itself).
+        expect(runs, 2);
+        // readAfterStop should NOT have a subscription from the stopped effect.
+        expect(() => readAfterStop.set(1), returnsNormally);
+        // No further runs.
+        expect(runs, 2);
+      },
+    );
+  });
+
+  group('Effect auto-dispose with Flutter Widget Context', () {
+    testWidgets('failed effect setup in widget does not leave subscription',
+        (tester) async {
+      final source = signal<Object?>(null, 0);
+      int runs = 0;
+      bool caught = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              if (!caught) {
+                try {
+                  effect(context, () {
+                    runs++;
+                    source();
+                    throw StateError('setup failed');
+                  });
+                } on StateError {
+                  caught = true;
+                }
+              }
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(runs, 1);
+      expect(caught, isTrue);
+
+      // Trigger the signal — the broken effect should not re-run.
+      (source as WritableSignal<Object?>).set(1);
+      await tester.pump();
+
+      expect(runs, 1);
+    });
+
+    testWidgets(
+        'failed effect scope in widget disposes child effects created before throw',
+        (tester) async {
+      final source = signal<Object?>(null, 0);
+      int childRuns = 0;
+      bool caught = false;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) {
+              if (!caught) {
+                try {
+                  effectScope(context, () {
+                    effect(context, () {
+                      childRuns++;
+                      source();
+                    });
+                    throw StateError('scope setup failed');
+                  });
+                } on StateError {
+                  caught = true;
+                }
+              }
+              return const SizedBox();
+            },
+          ),
+        ),
+      );
+
+      expect(childRuns, 1);
+      expect(caught, isTrue);
+
+      // The child effect should be disposed — signal change should not re-run it.
+      (source as WritableSignal<Object?>).set(1);
+      await tester.pump();
+
+      expect(childRuns, 1);
+    });
+  });
 }

--- a/test/core/effect_test.dart
+++ b/test/core/effect_test.dart
@@ -149,7 +149,7 @@ void main() {
       expect(disposed, isFalse);
 
       dispose();
-      expect(cleanupCount, equals(1)); // Cleanup doesn't run on dispose
+      expect(cleanupCount, equals(2)); // Cleanup runs before dispose
       expect(disposed, isTrue);
     });
 


### PR DESCRIPTION
## Summary

Upgrade alien_signals to 2.3.1 and implement auto-dispose on setup failure at the oref layer.

## Context

Upstream [alien-signals-dart#38](https://github.com/medz/alien-signals-dart/pull/38) removed the Dart-only auto-dispose-on-setup-failure behavior, treating it as a lifecycle policy decision for downstream code. This PR implements that policy in oref's wrapper layer and leverages new 2.3.1 features to simplify the codebase.

## Changes

### Dependency
- `alien_signals`: `^2.2.0` → `^2.3.1`

### Auto-dispose on setup failure
- Added `catch` blocks in `_createEffect()` and `_createEffectScope()` that auto-dispose partially-initialized nodes when the callback throws

### Simplifications (leveraging alien_signals 2.3.1)
- **`_OrefEffectScope`** now extends `EffectScopeNode` (new in 2.3.1) instead of `ReactiveNode`, giving proper propagation support
- **`call()` methods simplified**: removed 28 lines of manual `deps` iteration + switch/case dispatch, replaced with `alien.stop(this)` which dispatches to 2.3.1's built-in `stopEffect()`/ `stopScope()`
- **Renamed `cleanup` → `_userCleanup`** to avoid shadowing `EffectNode.cleanup` (new built-in cleanup mechanism in 2.3.1)

### Tests
- 5 new auto-dispose tests covering both Dart (`context: null`) and Flutter widget (`BuildContext`) contexts

## Diff
- `-28` lines of business code (effect.dart -11, effect_scope.dart -11 + catch blocks)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Effects now auto-dispose on initialization failures, ensuring no lingering subscriptions; cleanup runs before dispose and stopping during a run is handled correctly.
  * Child effects and scopes are properly disposed when a parent scope fails to initialize; improved error handling during effect execution for reliable recovery.

* **Tests**
  * Added extensive unit and widget tests covering auto-dispose, setup-failure cleanup, stop-during-run, and post-stop read behaviors.

* **Chores**
  * Updated signal library dependency for stability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->